### PR TITLE
Add feature to learn from others about known peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ],
       "devDependencies": {
         "@holochain-playground/cli": "^0.1.1",
-        "@theweave/cli": "0.13.0-beta.6",
+        "@theweave/cli": "0.13.0-beta.7",
         "concurrently": "^6.2.1",
         "electron": "^25.6.0",
         "rimraf": "^3.0.2"
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/@theweave/cli": {
-      "version": "0.13.0-beta.6",
-      "resolved": "https://registry.npmjs.org/@theweave/cli/-/cli-0.13.0-beta.6.tgz",
-      "integrity": "sha512-4EATx9+Ito4rzZIhwMeJqVv66E0cRE5SgqoZqUl3Oalh+Dbu66TPYqSGOJnZgJ532Np4pmHddJpJHlI1f3BuWQ==",
+      "version": "0.13.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@theweave/cli/-/cli-0.13.0-beta.7.tgz",
+      "integrity": "sha512-7HjGXNPFFxVSOgDlswRrlN3y8tw2wZWYq76Fc6PCw6bYrtMKlFSP9VNAqcZnwjZpgdt0BYu4u83Dk3i3MI4C6A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8674,7 +8674,7 @@
       }
     },
     "ui": {
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@fontsource-variable/baloo-2": "5.0.19",
         "@fontsource-variable/noto-sans-sc": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "network": "hc s clean && npm run build:happ && UI_PORT=8888 concurrently \"npm start -w ui\" \"npm run launch:happ\"",
     "test": "npm run build:zomes && hc app pack workdir --recursive && npm t -w tests",
     "applet-dev": "concurrently \"UI_PORT=8888 npm run start -w ui\" \"weave --agent-idx 1 --dev-config ./weave.dev.config.ts\" \"sleep 5 && weave --agent-idx 2 --dev-config ./weave.dev.config.ts --sync-time 6000\"",
-    "applet-dev-3": "concurrently \"UI_PORT=8888 npm run start -w ui\" \"weave --agent-idx 1 --dev-config ./weave.dev.config.ts\" \"sleep 5 && weave --agent-idx 2 --dev-config ./weave.dev.config.ts --sync-time 6000\" \"sleep 5 && weave --agent-idx 3 --dev-config ./weave.dev.config.ts --sync-time 6000\"",
+    "applet-dev-3": "concurrently \"UI_PORT=8888 npm run start -w ui\" \"weave --agent-idx 1 --dev-config ./weave.dev.config.ts\" \"sleep 5 && weave --agent-idx 2 --dev-config ./weave.dev.config.ts --sync-time 10000\" \"sleep 5 && weave --agent-idx 3 --dev-config ./weave.dev.config.ts --sync-time 10000\"",
     "applet-dev-1": "concurrently \"UI_PORT=8888 npm run start -w ui\" \"weave --agent-idx 1 --dev-config ./weave.dev.config.ts\"",
     "help": "weave --help",
     "launch:happ": "concurrently \"hc run-local-services --bootstrap-port 9998 --signal-port 9999\" \"echo pass | RUST_LOG=warn hc launch --piped -n $AGENTS workdir/presence.happ --ui-port $UI_PORT network --bootstrap http://127.0.0.1:9998 webrtc ws://127.0.0.1:9999\"",
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@holochain-playground/cli": "^0.1.1",
-    "@theweave/cli": "0.13.0-beta.6",
+    "@theweave/cli": "0.13.0-beta.7",
     "concurrently": "^6.2.1",
     "electron": "^25.6.0",
     "rimraf": "^3.0.2"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "scripts": {
     "start": "vite --port $UI_PORT --clearScreen false",
     "build": "vite build",

--- a/ui/src/agent-connection-status-icon.ts
+++ b/ui/src/agent-connection-status-icon.ts
@@ -1,5 +1,5 @@
 import { consume } from '@lit/context';
-import { hashProperty, sharedStyles } from '@holochain-open-dev/elements';
+import { hashProperty } from '@holochain-open-dev/elements';
 import { css, html, LitElement, PropertyValueMap } from 'lit';
 import { property, customElement } from 'lit/decorators.js';
 import { AgentPubKey, encodeHashToBase64 } from '@holochain/client';
@@ -20,6 +20,7 @@ import {
 import { EntryRecord } from '@holochain-open-dev/utils';
 import { ConnectionStatus } from './room-view';
 import { connectionStatusToColor } from './utils';
+import { sharedStyles } from './sharedStyles';
 
 @localized()
 @customElement('agent-connection-status-icon')
@@ -40,6 +41,9 @@ export class AgentConnectionStatusIcon extends LitElement {
 
   @property()
   connectionStatus: ConnectionStatus | undefined;
+
+  @property()
+  onlyToldAbout = false;
 
   /** Dependencies */
 
@@ -113,14 +117,33 @@ export class AgentConnectionStatusIcon extends LitElement {
 
   renderProfile(profile: EntryRecord<Profile> | undefined) {
     return html`
-      <div
-        class="row"
-        style="align-items: center; margin: 0; padding: 0; ${!this
-          .connectionStatus || this.connectionStatus.type === 'Disconnected'
-          ? 'opacity: 0.5'
-          : ''}"
+      <sl-tooltip
+        class="tooltip-filled"
+        placement="top"
+        hoist
+        content=${`${
+          profile ? profile.entry.nickname : 'Unknown'
+        } (${this.statusToText(this.connectionStatus)})\n new line`}
       >
-        <sl-tooltip class="tooltip-filled" placement="top" hoist content=${`${profile ? profile.entry.nickname : 'Unknown'} (${this.statusToText(this.connectionStatus)})`}>
+        <div
+          class="row"
+          style="position: relative; align-items: center; margin: 0; padding: 0; ${!this
+            .connectionStatus || this.connectionStatus.type === 'Disconnected'
+            ? 'opacity: 0.5'
+            : ''}"
+        >
+          ${this.onlyToldAbout
+            ? html`
+                <sl-tooltip
+                  hoist
+                  class="tooltip-filled tooltip-red"
+                  placement="bottom"
+                  content="has only learnt through signals from others that this person is part of the room"
+                >
+                  <div class="only-told-indicator tertiary-font">!</div>
+                </sl-tooltip>
+              `
+            : html``}
           ${profile && profile.entry.fields.avatar
             ? html`
                 <img
@@ -145,8 +168,8 @@ export class AgentConnectionStatusIcon extends LitElement {
                 >
                 </holo-identicon>
               `}
-        </sl-tooltip>
-      </div>
+        </div>
+      </sl-tooltip>
     `;
   }
 
@@ -187,6 +210,23 @@ export class AgentConnectionStatusIcon extends LitElement {
         --sl-tooltip-font-size: 14px;
         --sl-tooltip-color: #0d1543;
         --sl-tooltip-font-family: 'Ubuntu', sans-serif;
+      }
+
+      .tooltip-red {
+        --sl-tooltip-background-color: #ebc3c3;
+      }
+
+      .only-told-indicator {
+        position: absolute;
+        bottom: -1px;
+        right: -1px;
+        font-weight: bold;
+        color: white;
+        font-size: 12px;
+        background: red;
+        border-radius: 50%;
+        width: 14px;
+        height: 14px;
       }
     `,
   ];

--- a/ui/src/agent-connection-status.ts
+++ b/ui/src/agent-connection-status.ts
@@ -41,6 +41,9 @@ export class AgentConnectionStatus extends LitElement {
   @property()
   connectionStatus: ConnectionStatus | undefined;
 
+  @property()
+  appVersion: string | undefined;
+
   /** Dependencies */
 
   /**
@@ -115,6 +118,7 @@ export class AgentConnectionStatus extends LitElement {
     return html`
       <div
         class="row"
+        title="${this.appVersion ? `Uses Presence v${this.appVersion}` : `Uses unknown Presence version`}"
         style="align-items: center; margin: 0; padding: 0; ${!this
           .connectionStatus || this.connectionStatus.type === 'Disconnected'
           ? 'opacity: 0.5'

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,4 +1,5 @@
 import {
+  AgentPubKeyB64,
   AppInfo,
   CellType,
   ClonedCell,
@@ -103,4 +104,25 @@ export function connectionStatusToColor(status?: ConnectionStatus, offlineColor 
     default:
       return offlineColor;
   }
+}
+
+export const sortConnectionStatuses = (a: [AgentPubKeyB64, ConnectionStatus], b: [AgentPubKeyB64, ConnectionStatus]) => {
+  const [pubkey_a, status_a] = a;
+  const [pubkey_b, status_b] = b;
+  // If both have equal connection status, sort by pubkey
+  if (status_a.type === status_b.type) {
+    return pubkey_a.localeCompare(pubkey_b);
+  }
+  // Disconnected is last
+  if (status_a.type === "Disconnected") return 1;
+  if (status_b.type === "Disconnected") return -1;
+  // Everything else gets sorted by pubkey
+  return pubkey_a.localeCompare(pubkey_b);
+
+  // Connected is first - this is not being used for now as it may be harder to follow
+  // state changes visually if the icons move around
+  // if (status_a.type === "Connected") return 1;
+  // if (status_b.type === "Connected") return -1;
+
+
 }


### PR DESCRIPTION
This PR adds the feature that one can learn from others about peers that do not show up for oneself on the all_agents anchor but that they know about. It also adds associated UI to display these states.
Further adds the feature that the Presence version number is communicated to other peers.